### PR TITLE
Malcolm tyrrell/compliance tweaks

### DIFF
--- a/ExchangeToolkit/include/ExchangeToolkit.h
+++ b/ExchangeToolkit/include/ExchangeToolkit.h
@@ -1890,10 +1890,10 @@ namespace ts3d {
                         
                         _normals.push_back( current_n );
                         _vertices.push_back( current_v );
-                        _normals.push_back( vert % 2 ? next_n : prev_n );
-                        _vertices.push_back( vert % 2 ? next_v : prev_v );
-                        _normals.push_back( vert % 2 ? prev_n : next_n );
-                        _vertices.push_back( vert % 2 ? prev_v : next_v );
+                        _normals.push_back( (vert % 2) ? next_n : prev_n );
+                        _vertices.push_back( (vert % 2) ? next_v : prev_v );
+                        _normals.push_back( (vert % 2) ? prev_n : next_n );
+                        _vertices.push_back( (vert % 2) ? prev_v : next_v );
                     }
                     ti_index += 2;
                 }
@@ -1952,10 +1952,10 @@ namespace ts3d {
                         
                         _normals.push_back( current_n );
                         _vertices.push_back( current_v );
-                        _normals.push_back( vert % 2 ? next_n : prev_n );
-                        _vertices.push_back( vert % 2 ? next_v : prev_v );
-                        _normals.push_back( vert % 2 ? prev_n : next_n );
-                        _vertices.push_back( vert % 2 ? prev_v : next_v );
+                        _normals.push_back( (vert % 2) ? next_n : prev_n );
+                        _vertices.push_back( (vert % 2) ? next_v : prev_v );
+                        _normals.push_back( (vert % 2) ? prev_n : next_n );
+                        _vertices.push_back( (vert % 2) ? prev_v : next_v );
                     }
                     ti_index += (has_vertex_normals ? 2 : 1);
                 }
@@ -2031,13 +2031,13 @@ namespace ts3d {
                         _texture.insert( _texture.end(), current_t.begin(), current_t.end() );
                         _vertices.push_back( current_v );
                         
-                        _normals.push_back( vert % 2 ? next_n : prev_n );
-                        _texture.insert( _texture.end(), vert % 2 ? next_t.begin() : prev_t.begin(), vert % 2 ? next_t.end() : prev_t.end() );
+                        _normals.push_back( (vert % 2) ? next_n : prev_n );
+                        _texture.insert( _texture.end(), (vert % 2) ? next_t.begin() : prev_t.begin(), (vert % 2) ? next_t.end() : prev_t.end() );
                         _vertices.push_back( vert % 2 ? next_v : prev_v );
                         
                         _normals.push_back( vert % 2 ? prev_n : next_n );
-                        _texture.insert( _texture.end(), vert % 2 ? prev_t.begin() : next_t.begin(), vert % 2 ? prev_t.end() : next_t.end() );
-                        _vertices.push_back( vert % 2 ? prev_v : next_v );
+                        _texture.insert( _texture.end(), (vert % 2) ? prev_t.begin() : next_t.begin(), (vert % 2) ? prev_t.end() : next_t.end() );
+                        _vertices.push_back( (vert % 2) ? prev_v : next_v );
                     }
                 }
             }
@@ -2106,10 +2106,10 @@ namespace ts3d {
                         
                         _normals.push_back( current_n );
                         _vertices.push_back( current_v );
-                        _normals.push_back( vert % 2 ? next_n : prev_n );
-                        _vertices.push_back( vert % 2 ? next_v : prev_v );
-                        _normals.push_back( vert % 2 ? prev_n : next_n );
-                        _vertices.push_back( vert % 2 ? prev_v : next_v );
+                        _normals.push_back( (vert % 2) ? next_n : prev_n );
+                        _vertices.push_back( (vert % 2) ? next_v : prev_v );
+                        _normals.push_back( (vert % 2) ? prev_n : next_n );
+                        _vertices.push_back( (vert % 2) ? prev_v : next_v );
                     }
                 }
             }

--- a/ExchangeToolkit/include/ExchangeToolkit.h
+++ b/ExchangeToolkit/include/ExchangeToolkit.h
@@ -2033,7 +2033,7 @@ namespace ts3d {
                         
                         _normals.push_back( (vert % 2) ? next_n : prev_n );
                         _texture.insert( _texture.end(), (vert % 2) ? next_t.begin() : prev_t.begin(), (vert % 2) ? next_t.end() : prev_t.end() );
-                        _vertices.push_back( vert % 2 ? next_v : prev_v );
+                        _vertices.push_back( (vert % 2) ? next_v : prev_v );
                         
                         _normals.push_back( vert % 2 ? prev_n : next_n );
                         _texture.insert( _texture.end(), (vert % 2) ? prev_t.begin() : next_t.begin(), (vert % 2) ? prev_t.end() : next_t.end() );

--- a/ExchangeToolkit/include/ExchangeToolkit.h
+++ b/ExchangeToolkit/include/ExchangeToolkit.h
@@ -2035,7 +2035,7 @@ namespace ts3d {
                         _texture.insert( _texture.end(), (vert % 2) ? next_t.begin() : prev_t.begin(), (vert % 2) ? next_t.end() : prev_t.end() );
                         _vertices.push_back( (vert % 2) ? next_v : prev_v );
                         
-                        _normals.push_back( vert % 2 ? prev_n : next_n );
+                        _normals.push_back( (vert % 2) ? prev_n : next_n );
                         _texture.insert( _texture.end(), (vert % 2) ? prev_t.begin() : next_t.begin(), (vert % 2) ? prev_t.end() : next_t.end() );
                         _vertices.push_back( (vert % 2) ? prev_v : next_v );
                     }


### PR DESCRIPTION
A code quality tool we use complained about these conditional expressions:

error 6336:  : Arithmetic operator has precedence over question operator, use parentheses to clarify intent.

This trivial PR resolves that issue.