### PR TITLE
cross3 type error

### DIFF
--- a/ExchangeToolkit/include/ExchangeEigenBridge.h
+++ b/ExchangeToolkit/include/ExchangeEigenBridge.h
@@ -55,7 +55,7 @@ namespace {
 		auto const o = ts3d::getPosition( d->m_sOrigin );
 		auto const x = ts3d::getVector( d->m_sXVector );
 		auto const y = ts3d::getVector( d->m_sYVector );
-		auto const z = x.cross3( y ) * mirror;
+        ts3d::VectorType const z = x.cross3( y ) * mirror;
 
 		ts3d::MatrixType result;
 		for(auto idx = 0u; idx < 4u; idx++) {


### PR DESCRIPTION
In my release build, an auto type infers the wrong type of a vector cross product.

Comes up with 

`const CwiseBinaryOp<scalar_product_op<double>, const Matrix<double,4,1,0>, const CwiseNullaryOp<scalar_constant_op<double>, const Matrix<double,4,1,0>>>`

instead of 

`Matrix<double,4,1,0>`

which results in returning nonsense from ts3d::getNetMatrix.