### PR TITLE
Properly return general transformation info in getMatrix

### DIFF
--- a/ExchangeToolkit/include/ExchangeEigenBridge.h
+++ b/ExchangeToolkit/include/ExchangeEigenBridge.h
@@ -101,8 +101,8 @@ namespace ts3d {
 			return getMatrixFromCartesian( xform );
 			break;
 		case kA3DTypeMiscGeneralTransformation:
-			break;
 			return getMatrixFromGeneralTransformation( xform );
+			break;
 		default:
 			throw std::invalid_argument( "Unexpected argument type provided" );
 			break;


### PR DESCRIPTION
The lines need to be swapped, or the breaks removed when used with return. 